### PR TITLE
Change plugin title to GitHub

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 ﻿{
   "ID": "6c22cffe6b3546ec9087abe149c4a575",
   "ActionKeyword": "gh",
-  "Name": "Flow.Plugin.Github",
+  "Name": "GitHub",
   "Description": "Search Github repositories and users, browse issues and PRs",
   "Author": "Ioannis G. (@JohnTheGr8)",
   "Version": "1.2.1",


### PR DESCRIPTION
Shall we just call/display this plugin as 'GitHub' instead of 'Flow.Plugin.Github'?